### PR TITLE
Redis strategy crashes because shop data isn't being returned

### DIFF
--- a/strategies/RedisStrategy.js
+++ b/strategies/RedisStrategy.js
@@ -12,7 +12,7 @@ module.exports = class RedisStrategy {
         done(err);
       }
 
-      done(null, clientToken);
+      done(null, shopData);
     });
   }
 


### PR DESCRIPTION
Issue originally created in `shopify-node-app` repo (https://github.com/Shopify/shopify-node-app/issues/55) 