### PR TITLE
fix: The webhooks.js didn't work 

### DIFF
--- a/middleware/webhooks.js
+++ b/middleware/webhooks.js
@@ -7,9 +7,16 @@ module.exports = function createWithWebhook({ secret, shopStore }) {
     const topic = request.get('X-Shopify-Topic');
     const shopDomain = request.get('X-Shopify-Shop-Domain');
 
+    // Shopify seems to be escaping forward slashes when the build the HMAC
+    // so we need to do the same otherwise it will fail validation
+    // Shopify also seems to replace '&' with \u0026 ...
+    let message = JSON.stringify(data)
+    message = message.split('/').join('\\/');
+    message = message.split('&').join('\\u0026');
+
     const generated_hash = crypto
-      .createHmac('sha256', SHOPIFY_APP_SECRET)
-      .update(JSON.stringify(data))
+      .createHmac('sha256', secret)
+      .update(message)
       .digest('base64');
 
     if (generated_hash !== hmac) {

--- a/middleware/webhooks.js
+++ b/middleware/webhooks.js
@@ -7,9 +7,9 @@ module.exports = function createWithWebhook({ secret, shopStore }) {
     const topic = request.get('X-Shopify-Topic');
     const shopDomain = request.get('X-Shopify-Shop-Domain');
 
-    // Shopify seems to be escaping forward slashes when the build the HMAC
-    // so we need to do the same otherwise it will fail validation
-    // Shopify also seems to replace '&' with \u0026 ...
+    // Shopify escapes forward slashes 
+    // + replaces '&' with \u0026 when the HMAC is built
+    // so we need to do the same otherwise the validation will fail
     let message = JSON.stringify(data)
     message = message.split('/').join('\\/');
     message = message.split('&').join('\\u0026');

--- a/routes/shopifyApiProxy.js
+++ b/routes/shopifyApiProxy.js
@@ -1,6 +1,6 @@
 const { URL } = require('url');
 
-const ALLOWED_URLS = ['/products', '/orders'];
+const ALLOWED_URLS = ['/products', '/orders', '/product_listings'];
 
 module.exports = function shopifyApiProxy(request, response, next) {
   const { query, method, path, body, session } = request;


### PR DESCRIPTION
I had a 500 error because of the "SHOPIFY_APP_SECRET" var that doesn't exist, it is "secret".

After the first bug fixed, I had a 401, because the HMAC was not computed correctly : The HMAC calculation needs some manipulation on the data received (see the code)
Thanks to https://github.com/jonpulice/node-shopify-auth/blob/master/lib/main.js, his fix on verifyWebhookHMAC did the trick

;)
Greg