### PR TITLE
don't expect body parser to be used

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "body-parser": "^1.18.2",
     "connect-redis": "^3.3.0",
     "express": "^4.16.2",
     "express-session": "^1.15.3",

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const bodyParser = require('body-parser');
 
 const createWithShop = require('../middleware/withShop');
 const createShopifyAuthRouter = require('./shopifyAuth');
@@ -6,9 +7,10 @@ const shopifyApiProxy = require('./shopifyApiProxy');
 
 module.exports = function createRouter(shopifyConfig) {
   const router = express.Router();
+  const rawParser = bodyParser.raw({type: '*/*'});
 
   router.use('/auth/shopify', createShopifyAuthRouter(shopifyConfig));
-  router.use('/api', createWithShop({ redirect: false }), shopifyApiProxy);
+  router.use('/api', rawParser, createWithShop({ redirect: false }), shopifyApiProxy);
 
   return router;
 };

--- a/routes/shopifyApiProxy.js
+++ b/routes/shopifyApiProxy.js
@@ -3,7 +3,7 @@ const { URL } = require('url');
 const ALLOWED_URLS = ['/products', '/orders'];
 
 module.exports = function shopifyApiProxy(request, response, next) {
-  const { query, method, path, body, session } = request;
+  const { query, method, path, session } = request;
   const { shop, accessToken } = session;
 
   const strippedPath = path.split('?')[0].split('.json')[0];
@@ -18,7 +18,7 @@ module.exports = function shopifyApiProxy(request, response, next) {
 
   const fetchOptions = {
     method,
-    body,
+    body: request.read(),
     headers: {
       'Content-Type': 'application/json',
       'X-Shopify-Access-Token': accessToken,

--- a/routes/shopifyApiProxy.js
+++ b/routes/shopifyApiProxy.js
@@ -3,22 +3,16 @@ const { URL } = require('url');
 const ALLOWED_URLS = ['/products', '/orders'];
 
 module.exports = function shopifyApiProxy(request, response, next) {
-  const { query, method, path, session } = request;
+  const { query, method, path, body, session } = request;
   const { shop, accessToken } = session;
 
-  const strippedPath = path.split('?')[0].split('.json')[0];
-
-  const inAllowed = ALLOWED_URLS.some(resource => {
-    return strippedPath === resource;
-  });
-
-  if (!inAllowed) {
+  if (!validRequest(path)) {
     return response.status(403).send('Endpoint not in whitelist');
   }
 
   const fetchOptions = {
     method,
-    body: request.read(),
+    body,
     headers: {
       'Content-Type': 'application/json',
       'X-Shopify-Access-Token': accessToken,
@@ -35,6 +29,14 @@ module.exports = function shopifyApiProxy(request, response, next) {
     })
     .catch(err => response.err(err));
 };
+
+function validRequest(path) {
+  const strippedPath = path.split('?')[0].split('.json')[0];
+
+  return ALLOWED_URLS.some(resource => {
+    return strippedPath === resource;
+  });
+}
 
 function fetchWithParams(url, fetchOpts, query) {
   const parsedUrl = new URL(url);

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,8 +35,8 @@ ajv@^4.9.1:
     json-stable-stringify "^1.0.1"
 
 ajv@^5.1.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.4.0.tgz#32d1cf08dbc80c432f426f12e10b2511f6b46474"
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.0.tgz#eb2840746e9dc48bd5e063a36e3fd400c5eab5a9"
   dependencies:
     co "^4.6.0"
     fast-deep-equal "^1.0.0"
@@ -339,7 +339,7 @@ bluebird@^3.4.6:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
-body-parser@1.18.2:
+body-parser@1.18.2, body-parser@^1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.2.tgz#87678a19d84b47d859b83199bd59bce222b10454"
   dependencies:
@@ -493,8 +493,8 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
     delayed-stream "~1.0.0"
 
 commander@^2.2.0:
-  version "2.11.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+  version "2.12.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.12.1.tgz#468635c4168d06145b9323356d1da84d14ac4a7a"
 
 component-emitter@^1.2.0:
   version "1.2.1"
@@ -528,8 +528,8 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
 convert-source-map@^1.4.0, convert-source-map@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -650,8 +650,8 @@ detect-indent@^4.0.0:
     repeating "^2.0.0"
 
 detect-libc@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.2.tgz#71ad5d204bf17a6a6ca8f450c61454066ef461e1"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
 
 diff@^3.2.0:
   version "3.4.0"
@@ -1214,8 +1214,8 @@ inherits@2, inherits@2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
 ini@^1.3.4, ini@~1.3.0:
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
 interpret@^0.6.5:
   version "0.6.6"
@@ -1888,9 +1888,13 @@ mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.17, 
   dependencies:
     mime-db "~1.30.0"
 
-mime@1.4.1, mime@^1.4.1:
+mime@1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
+
+mime@^1.4.1:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
 
 mimic-fn@^1.0.0:
   version "1.1.0"
@@ -2214,8 +2218,8 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
 prettier@^1.5.2:
-  version "1.7.4"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.8.2.tgz#bff83e7fd573933c607875e5ba3abbdffb96aeb8"
 
 pretty-format@^21.2.1:
   version "21.2.1"


### PR DESCRIPTION
I discovered this issue while working on https://github.com/Shopify/shopify-node-app/pull/47. BodyParser gives us easy access to the body but then we would need to Stringify the body again before proxing the request to the API. It seems to me like it would be simpler to not assume BodyParser is present.

@TheMallen @jamiemtdwyer 