### PR TITLE
✨ configurable SQL strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ const shopifyExpress = require('@shopify/shopify-express');
 const {MemoryStrategy} = require('@shopify/shopify-express/strategies');
 
 const shopify = shopifyExpress({
-  shopStore: new RedisStrategy(redisConfig),
+  shopStore: new MemoryStrategy(redisConfig),
   ...restOfConfig,
 });
 ```
@@ -122,12 +122,12 @@ If you do not have a table already created for your store, you can generate one 
 `shopifyExpress` accepts any javascript class matching the following interface:
 
 ```javascript
-  interface Strategy {
+  class Strategy {
     // shop refers to the shop's domain name
-    getShop({ shop }, done)): void
+    getShop({ shop }, done))
     // shop refers to the shop's domain name
     // data can by any serializable object
-    storeShop({ shop, accessToken, data }, done): void
+    storeShop({ shop, accessToken, data }, done)
   }
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,30 +62,72 @@ endpoints from a client application without having to worry about CORS.
 
 By default the package comes with `MemoryStrategy`, `RedisStrategy`, and `SqliteStrategy`. If none are specified, the default is `MemoryStrategy`.
 
-You can use them in a config like so:
+#### MemoryStrategy
+
+Simple javascript object based memory store for development purposes. Do not use this in production!
+
+```javascript
+const shopifyExpress = require('@shopify/shopify-express');
+const {MemoryStrategy} = require('@shopify/shopify-express/strategies');
+
+const shopify = shopifyExpress({
+  shopStore: new RedisStrategy(redisConfig),
+  ...restOfConfig,
+});
+```
+
+#### RedisStrategy
+
+Uses [redis](https://www.npmjs.com/package/redis) under the hood, so you can pass it any configuration that's valid for the library.
 
 ```javascript
 const shopifyExpress = require('@shopify/shopify-express');
 const {RedisStrategy} = require('@shopify/shopify-express/strategies');
 
+const redisConfig = {
+  // your config here
+};
+
 const shopify = shopifyExpress({
-  shopStore: new RedisStrategy(),
+  shopStore: new RedisStrategy(redisConfig),
   ...restOfConfig,
 });
 ```
 
-### Custom Strategy
+#### SQLStrategy
 
-`shopifyExpress` takes a `shopStore` parameter. This can be any javascript class matching the following interface:
+Uses [knex](https://www.npmjs.com/package/knex) under the hood, so you can pass it any configuration that's valid for the library. By default it uses `sqlite3` so you'll need to run `yarn add sqlite3` to use it. Knex also supports `postgreSQL` and `mySQL`.
 
 ```javascript
-  class Strategy {
-    constructor(){}
+const shopifyExpress = require('@shopify/shopify-express');
+const {SQLStrategy} = require('@shopify/shopify-express/strategies');
+
+// uses sqlite3 if no settings are specified
+const knexConfig = {
+  // your config here
+};
+
+const shopify = shopifyExpress({
+  shopStore: new SQLStrategy(knexConfig),
+  ...restOfConfig,
+});
+```
+
+SQLStrategy expects a table named `shops` with a primary key `id`, and `string` fields for `shop_domain` and `access_token`. It's recommended you index `shop_domain` since it is used to look up tokens.
+
+If you do not have a table already created for your store, you can generate one with `new SQLStrategy(myConfig).initialize()`. This returns a promise so you can finish setting up your app after it if you like, but we suggest you make a separate db initialization script, or keep track of your schema yourself.
+
+#### Custom Strategy
+
+`shopifyExpress` accepts any javascript class matching the following interface:
+
+```javascript
+  interface Strategy {
     // shop refers to the shop's domain name
-    getShop({ shop }, done)){}
+    getShop({ shop }, done)): void
     // shop refers to the shop's domain name
     // data can by any serializable object
-    storeShop({ shop, accessToken, data }, done){}
+    storeShop({ shop, accessToken, data }, done): void
   }
 ```
 

--- a/strategies/MemoryStrategy.js
+++ b/strategies/MemoryStrategy.js
@@ -6,9 +6,7 @@ module.exports = class MemoryStrategy {
   storeShop({ shop, accessToken, data = {} }, done) {
     this.store[shop] = Object.assign(
       {},
-      {
-        accessToken,
-      },
+      { accessToken },
       data
     );
 

--- a/strategies/RedisStrategy.js
+++ b/strategies/RedisStrategy.js
@@ -1,8 +1,8 @@
 const Redis = require('redis');
 
 module.exports = class RedisStrategy {
-  constructor() {
-    this.client = Redis.createClient();
+  constructor(redisConfig) {
+    this.client = Redis.createClient(redisConfig);
   }
 
   storeShop({ shop, accessToken, data = {} }, done) {

--- a/strategies/SQLStrategy.js
+++ b/strategies/SQLStrategy.js
@@ -1,16 +1,20 @@
 const Knex = require('knex');
 
-module.exports = class SqliteStrategy {
-  constructor() {
-    this.knex = Knex({
-      dialect: 'sqlite3',
-      useNullAsDefault: true,
-      connection: {
-        filename: './db.sqlite3',
-      },
-    });
+const defaultConfig = {
+  dialect: 'sqlite3',
+  useNullAsDefault: true,
+  connection: {
+    filename: './db.sqlite3',
+  },
+};
 
-    this.knex.schema
+module.exports = class SQLStrategy {
+  constructor(config = defaultConfig) {
+    this.knex = Knex(config);
+  }
+
+  initialize() {
+    return this.knex.schema
       .createTableIfNotExists('shops', table => {
         table.increments('id');
         table.string('shopify_domain');

--- a/strategies/index.js
+++ b/strategies/index.js
@@ -1,9 +1,9 @@
 const RedisStrategy = require('./RedisStrategy');
 const MemoryStrategy = require('./MemoryStrategy');
-const SqliteStrategy = require('./SqliteStrategy');
+const SQLStrategy = require('./SQLStrategy');
 
 module.exports = {
   RedisStrategy,
   MemoryStrategy,
-  SqliteStrategy,
+  SQLStrategy,
 }


### PR DESCRIPTION
closes #3 

This PR converts our `SQLiteStrategy` to a more generic `SQLStrategy`, and cleans up some other details around configuring strategies.

Check out the updated to the README for more details.