### PR TITLE
Use correct secret and don't assume bodyParser.json

### DIFF
--- a/middleware/webhooks.js
+++ b/middleware/webhooks.js
@@ -1,29 +1,44 @@
 const crypto = require('crypto');
+const getRawBody = require('raw-body');
 
-module.exports = function createWithWebhook({ secret, shopStore }) {
-  return function withWebhook(request, response, next) {
-    const { body: data } = request;
-    const hmac = request.get('X-Shopify-Hmac-Sha256');
-    const topic = request.get('X-Shopify-Topic');
-    const shopDomain = request.get('X-Shopify-Shop-Domain');
+module.exports = function configureWithWebhook({ secret, shopStore }) {
+  return function createWebhookHandler(onVerified) {
+    return async function withWebhook(request, response) {
+      const { body: data } = request;
+      const hmac = request.get('X-Shopify-Hmac-Sha256');
+      const topic = request.get('X-Shopify-Topic');
+      const shopDomain = request.get('X-Shopify-Shop-Domain');
 
-    const generated_hash = crypto
-      .createHmac('sha256', secret)
-      .update(data)
-      .digest('base64');
+      try {
+        const rawBody = await getRawBody(request);
+        const generated_hash = crypto
+          .createHmac('sha256', secret)
+          .update(rawBody)
+          .digest('base64');
 
-    if (generated_hash !== hmac) {
-      return response.status(401).send("Request doesn't pass HMAC validation");
-    }
+        if (generated_hash !== hmac) {
+          response.status(401).send();
+          onVerified(new Error("Unable to verify request HMAC"));
+          return;
+        }
 
-    shopStore.getShop({ shop: shopDomain }, (error, { accessToken }) => {
-      if (error) {
-        next(error);
+        shopStore.getShop({ shop: shopDomain }, (error, { accessToken }) => {
+          if (error) {
+            response.status(401).send();
+            onVerified(new Error("Couldn't fetch credentials for shop"));
+            return;
+          }
+
+          request.body = rawBody.toString('utf8');
+          request.webhook = { topic, shopDomain, accessToken };
+
+          response.status(200).send();
+
+          onVerified(null, request);
+        });
+      } catch(error) {
+        response.send(error);
       }
-
-      request.webhook = { topic, shopDomain, accessToken };
-
-      next();
-    });
-  };
+    };
+  }
 };

--- a/middleware/webhooks.js
+++ b/middleware/webhooks.js
@@ -8,8 +8,8 @@ module.exports = function createWithWebhook({ secret, shopStore }) {
     const shopDomain = request.get('X-Shopify-Shop-Domain');
 
     const generated_hash = crypto
-      .createHmac('sha256', SHOPIFY_APP_SECRET)
-      .update(JSON.stringify(data))
+      .createHmac('sha256', secret)
+      .update(data)
       .digest('base64');
 
     if (generated_hash !== hmac) {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "node-fetch": "^1.7.3",
     "redis": "^2.7.1",
     "sqlite3": "^3.1.9",
-    "url": "^0.11.0"
+    "url": "^0.11.0",
+    "raw-body": "^2.3.2"
   },
   "devDependencies": {
     "husky": "^0.14.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2568,7 +2568,7 @@ range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-raw-body@2.3.2:
+raw-body@2.3.2, raw-body@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"
   dependencies:


### PR DESCRIPTION
Use correct variable for secret key (`secret` which is now passed into the middleware, rather than `SHOPIFY_APP_SECRET`, and stop stringifying the body from JSON.

This makes webhook verification work correctly, as long as the consuming app isn't using `bodyParser.json()` to parse the request body.

As far as I understand it, in order to make this bulletproof (to work regardless of the downstream app configuration), we need to use some kind of explicit body parsing in our webhook middleware. That's the part I'm a bit stuck on and will probably need some more help with.