### PR TITLE
Make correction to database field name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ const shopify = shopifyExpress({
 });
 ```
 
-SQLStrategy expects a table named `shops` with a primary key `id`, and `string` fields for `shop_domain` and `access_token`. It's recommended you index `shop_domain` since it is used to look up tokens.
+SQLStrategy expects a table named `shops` with a primary key `id`, and `string` fields for `shopify_domain` and `access_token`. It's recommended you index `shopify_domain` since it is used to look up tokens.
 
 If you do not have a table already created for your store, you can generate one with `new SQLStrategy(myConfig).initialize()`. This returns a promise so you can finish setting up your app after it if you like, but we suggest you make a separate db initialization script, or keep track of your schema yourself.
 


### PR DESCRIPTION
The README describes the structure of the database table required to store shops and access tokens. 

One column `shop_domain`, does not match the name in the code (see https://github.com/Shopify/shopify-express/blob/master/strategies/SQLStrategy.js). 

Corrected to be `shopify_domain` to match code.