### PR TITLE
Fix/session shenanigans

### DIFF
--- a/routes/shopifyApiProxy.js
+++ b/routes/shopifyApiProxy.js
@@ -17,8 +17,14 @@ module.exports = async function shopifyApiProxy(incomingRequest, response, next)
   const { query, method, path: pathname, body, session } = incomingRequest;
   const { shop, accessToken } = session;
 
+  if (shop == null || accessToken == null) {
+    response.status(401).send(new Error('Unauthorized'));
+    return;
+  }
+
   if (!validRequest(pathname)) {
-    return response.status(403).send('Endpoint not in whitelist');
+    response.status(403).send('Endpoint not in whitelist');
+    return;
   }
 
   try {

--- a/routes/shopifyApiProxy.js
+++ b/routes/shopifyApiProxy.js
@@ -15,6 +15,13 @@ const DISALLOWED_URLS = [
 
 module.exports = async function shopifyApiProxy(incomingRequest, response, next) {
   const { query, method, path: pathname, body, session } = incomingRequest;
+
+  if (session == null) {
+    console.error('A session middleware must be installed to use ApiProxy.')
+    response.status(401).send(new Error('Unauthorized'));
+    return;
+  }
+
   const { shop, accessToken } = session;
 
   if (shop == null || accessToken == null) {

--- a/routes/tests/shopifyApiProxy.test.js
+++ b/routes/tests/shopifyApiProxy.test.js
@@ -32,6 +32,20 @@ describe('shopifyApiProxy', async () => {
     server.close();
   });
 
+  it('errors when shop information is not in session', async () => {
+    const shop = 'some-shop.com';
+    const endpoint = '/products';
+    session.shop = null;
+    session.accessToken = null;
+
+    const expectedPath = `https://${shop}/admin${endpoint}`;
+    const response = await fetch(`${BASE_URL}${API_ROUTE}${endpoint}`);
+
+    expect(fetchMock).not.toBeCalled();
+    expect(response.status).toBe(401);
+  });
+
+
   it('proxies requests to the shop given in session', async () => {
     const shop = 'some-shop.com';
     const endpoint = '/products';

--- a/routes/tests/shopifyAuth.test.js
+++ b/routes/tests/shopifyAuth.test.js
@@ -39,6 +39,24 @@ describe('shopifyAuth', async () => {
       expect(data).toMatchSnapshot();
     });
   });
+
+  describe('/callback', () => {
+    it('errors when hmac validation fails', () => {
+      pending();
+    });
+
+    it('does not error when hmac validation succeds', () => {
+      pending();
+    });
+
+    it('requests access token', () => {
+      pending();
+    });
+
+    it('console warns when no session is present on request context', () => {
+      pending();
+    });
+  });
 });
 
 function createServer(afterAuth) {


### PR DESCRIPTION
closes #45 
closes #21 
closes #33 

This PR adds some error logic for common gotchas, as well as documentation.

It also fixes `ShopifyAuth` breaking when no session is configured (though I added a warning since most of the package does need one).