### PR TITLE
🛠️ callbacks use router base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const {routes, withShop} = shopifyExpress({
 app.use('/shopify', routes);
 
 // shields myAppMiddleware from being accessed without session
-app.use('/myApp', withShop('/shopify'), myAppMiddleware)
+app.use('/myApp', withShop({authBaseUrl: '/shopify'}), myAppMiddleware)
 ```
 
 ## Shopify routes
@@ -144,7 +144,7 @@ If you do not have a table already created for your store, you can generate one 
 
 ### `withShop`
 
-`app.use('/someProtectedPath', withShop('/shopify'), someHandler);`
+`app.use('/someProtectedPath', withShop({authBaseUrl: '/shopify'}), someHandler);`
 
 Express middleware that validates the presence of your shop session. The parameter you pass to it should match the base URL for where you've mounted the shopify routes.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ const {
 // session is necessary for api proxy and auth verification
 app.use(session({secret: SHOPIFY_APP_SECRET}));
 
-const shopify = shopifyExpress({
+const {routes, withShop} = shopifyExpress({
   host: SHOPIFY_APP_HOST,
   apiKey: SHOPIFY_APP_KEY,
   secret: SHOPIFY_APP_SECRET,
@@ -36,8 +36,11 @@ const shopify = shopifyExpress({
   },
 });
 
-// mounts '/auth/shopify' and '/api' off of '/'
-app.use('/', shopify.routes);
+// mounts '/auth' and '/api' off of '/'
+app.use('/shopify', routes);
+
+// shields myAppMiddleware from being accessed without session
+app.use('/myApp', withShop('/shopify'), myAppMiddleware)
 ```
 
 ## Shopify routes
@@ -141,9 +144,9 @@ If you do not have a table already created for your store, you can generate one 
 
 ### `withShop`
 
-`app.use('/someProtectedPath', withShop, someHandler);`
+`app.use('/someProtectedPath', withShop('/shopify'), someHandler);`
 
-Express middleware that validates the presence of your shop session.
+Express middleware that validates the presence of your shop session. The parameter you pass to it should match the base URL for where you've mounted the shopify routes.
 
 ### `withWebhook`
 
@@ -155,8 +158,10 @@ Express middleware that validates the presence of a valid HMAC signature to allo
 
 You can look at [shopify-node-app](https://github.com/shopify/shopify-node-app) for a complete working example.
 
-
 ## Gotchas
+
+### Install route
+For the moment the app expects you to mount your install route at `/install`. See [shopify-node-app](https://github.com/shopify/shopify-node-app) for details.
 
 ### Express Session
 This library expects [express-session](https://www.npmjs.com/package/express-session) or a compatible library to be installed and set up for much of it's functionality. Api Proxy and auth verification functions won't work without something putting a `session` key on `request`.

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -1,9 +1,8 @@
 const createWithWebhook = require('./webhooks');
-const createWithShop = require('./withShop');
+const withShop = require('./withShop');
 
 module.exports = function createMiddleware(shopifyConfig) {
   const withWebhook = createWithWebhook(shopifyConfig);
-  const withShop = createWithShop();
 
   return {
     withShop,

--- a/middleware/withShop.js
+++ b/middleware/withShop.js
@@ -1,19 +1,18 @@
-module.exports = function withShop({ redirect } = { redirect: true }) {
+module.exports = function withShop({ authBaseUrl } = {}) {
   return function verifyRequest(request, response, next) {
-    const { query: { shop }, session } = request;
+    const { query: { shop }, session, baseUrl } = request;
 
     if (session && session.accessToken) {
-      return next();
+      next();
+      return;
     }
 
-    if (shop && redirect) {
-      return response.redirect(`/auth/shopify?shop=${shop}`);
+    if (shop) {
+      response.redirect(`${authBaseUrl || baseUrl}/auth?shop=${shop}`);
+      return;
     }
 
-    if (redirect) {
-      return response.redirect('/install');
-    }
-
-    return response.status(401).json('Unauthorized');
+    response.redirect('/install');
+    return;
   };
 };

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,21 +1,34 @@
 const express = require('express');
 const bodyParser = require('body-parser');
 
-const createWithShop = require('../middleware/withShop');
-const createShopifyAuthRouter = require('./shopifyAuth');
+const createShopifyAuthRoutes = require('./shopifyAuth');
 const shopifyApiProxy = require('./shopifyApiProxy');
 
 module.exports = function createRouter(shopifyConfig) {
   const router = express.Router();
   const rawParser = bodyParser.raw({ type: '*/*' });
+  const {auth, callback} = createShopifyAuthRoutes(shopifyConfig)
 
-  router.use('/auth/shopify', createShopifyAuthRouter(shopifyConfig));
+  router.use('/auth/callback', callback);
+  router.use('/auth', auth);
   router.use(
     '/api',
     rawParser,
-    createWithShop({ redirect: false }),
+    verifyApiCall,
     shopifyApiProxy,
   );
 
   return router;
 };
+
+function verifyApiCall(request, response, next) {
+  const {session} = request;
+
+  if (session && session.accessToken) {
+    next();
+    return;
+  }
+
+  response.status(401).send();
+  return;
+}

--- a/routes/shopifyAuth.js
+++ b/routes/shopifyAuth.js
@@ -1,9 +1,8 @@
-const express = require('express');
 const querystring = require('querystring');
 const crypto = require('crypto');
 const fetch = require('node-fetch');
 
-module.exports = function createShopifyAuthRouter({
+module.exports = function createShopifyAuthRoutes({
   host,
   apiKey,
   secret,
@@ -11,93 +10,91 @@ module.exports = function createShopifyAuthRouter({
   afterAuth,
   shopStore,
 }) {
-  const router = express.Router();
+  return {
+    // This function initializes the Shopify OAuth Process
+    auth(request, response) {
+      const { query, baseUrl } = request;
+      const { shop } = query;
 
-  // This function initializes the Shopify OAuth Process
-  router.get('/', function(request, response) {
-    const { query } = request;
-    const { shop } = query;
-
-    if (shop == null) {
-      return response.status(400).send('Expected a shop query parameter');
-    }
-
-    const redirectTo = `https://${shop}/admin/oauth/authorize`;
-    const redirectParams =
-      `?client_id=${apiKey}&scope=${scope}&redirect_uri=${host}` +
-      '/auth/shopify/callback';
-
-    response.send(
-      `<!DOCTYPE html>
-      <html>
-        <head>
-          <script type="text/javascript">
-            window.top.location.href = "${redirectTo}${redirectParams}"
-          </script>
-        </head>
-      </html>`,
-    );
-  });
-
-  // Users are redirected here after clicking `Install`.
-  // The redirect from Shopify contains the authorization_code query parameter,
-  // which the app exchanges for an access token
-  router.get('/callback', async (request, response) => {
-    const { query } = request;
-    const { code, hmac, shop } = query;
-
-    const map = JSON.parse(JSON.stringify(query));
-    delete map['signature'];
-    delete map['hmac'];
-
-    const message = querystring.stringify(map);
-    const generated_hash = crypto
-      .createHmac('sha256', secret)
-      .update(message)
-      .digest('hex');
-
-    if (generated_hash !== hmac) {
-      return response.status(400).send('HMAC validation failed');
-    }
-
-    if (shop == null) {
-      return response.status(400).send('Expected a shop query parameter');
-    }
-
-    const requestBody = querystring.stringify({
-      code,
-      client_id: apiKey,
-      client_secret: secret,
-    });
-
-    const remoteResponse = await fetch(`https://${shop}/admin/oauth/access_token`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-        'Content-Length': Buffer.byteLength(requestBody),
-      },
-      body: requestBody,
-    });
-
-    const responseBody = await remoteResponse.json();
-
-    const accessToken = responseBody.access_token;
-
-    shopStore.storeShop({ accessToken, shop }, (err, token) => {
-      if (err) {
-        console.error('🔴 Error storing shop access token', err);
+      if (shop == null) {
+        return response.status(400).send('Expected a shop query parameter');
       }
 
-      if (request.session) {
-        request.session.accessToken = accessToken;
-        request.session.shop = shop;
-      } else {
-        console.warn('Session not present on request, please install a session middleware.');
+      const redirectTo = `https://${shop}/admin/oauth/authorize`;
+      const redirectParams =
+        `?client_id=${apiKey}&scope=${scope}&redirect_uri=${host}` +
+        `${baseUrl}/callback`;
+
+      response.send(
+        `<!DOCTYPE html>
+        <html>
+          <head>
+            <script type="text/javascript">
+              window.top.location.href = "${redirectTo}${redirectParams}"
+            </script>
+          </head>
+        </html>`,
+      );
+    },
+
+    // Users are redirected here after clicking `Install`.
+    // The redirect from Shopify contains the authorization_code query parameter,
+    // which the app exchanges for an access token
+    async callback(request, response) {
+      const { query } = request;
+      const { code, hmac, shop } = query;
+
+      const map = JSON.parse(JSON.stringify(query));
+      delete map['signature'];
+      delete map['hmac'];
+
+      const message = querystring.stringify(map);
+      const generated_hash = crypto
+        .createHmac('sha256', secret)
+        .update(message)
+        .digest('hex');
+
+      if (generated_hash !== hmac) {
+        return response.status(400).send('HMAC validation failed');
       }
 
-      afterAuth(request, response);
-    });
-  });
+      if (shop == null) {
+        return response.status(400).send('Expected a shop query parameter');
+      }
 
-  return router;
+      const requestBody = querystring.stringify({
+        code,
+        client_id: apiKey,
+        client_secret: secret,
+      });
+
+      const remoteResponse = await fetch(`https://${shop}/admin/oauth/access_token`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'Content-Length': Buffer.byteLength(requestBody),
+        },
+        body: requestBody,
+      });
+
+      const responseBody = await remoteResponse.json();
+
+      const accessToken = responseBody.access_token;
+
+      shopStore.storeShop({ accessToken, shop }, (err, token) => {
+        if (err) {
+          console.error('🔴 Error storing shop access token', err);
+        }
+
+        if (request.session) {
+          request.session.accessToken = accessToken;
+          request.session.shop = shop;
+        } else {
+          console.warn('Session not present on request, please install a session middleware.');
+        }
+
+        afterAuth(request, response);
+      });
+    }
+  };
 };

--- a/routes/tests/__snapshots__/shopifyAuth.test.js.snap
+++ b/routes/tests/__snapshots__/shopifyAuth.test.js.snap
@@ -2,13 +2,13 @@
 
 exports[`shopifyAuth / responds to get requests by returning a redirect page 1`] = `
 "<!DOCTYPE html>
-      <html>
-        <head>
-          <script type=\\"text/javascript\\">
-            window.top.location.href = \\"https://shop1/admin/oauth/authorize?client_id=key&scope=scope&redirect_uri=undefined/auth/shopify/callback\\"
-          </script>
-        </head>
-      </html>"
+        <html>
+          <head>
+            <script type=\\"text/javascript\\">
+              window.top.location.href = \\"https://shop1/admin/oauth/authorize?client_id=key&scope=scope&redirect_uri=undefined/auth/callback\\"
+            </script>
+          </head>
+        </html>"
 `;
 
 exports[`shopifyAuth / responds with a 400 when no shop query parameter is given 1`] = `"Expected a shop query parameter"`;

--- a/routes/tests/__snapshots__/shopifyAuth.test.js.snap
+++ b/routes/tests/__snapshots__/shopifyAuth.test.js.snap
@@ -5,7 +5,7 @@ exports[`shopifyAuth / responds to get requests by returning a redirect page 1`]
         <html>
           <head>
             <script type=\\"text/javascript\\">
-              window.top.location.href = \\"https://shop1/admin/oauth/authorize?client_id=key&scope=scope&redirect_uri=undefined/auth/callback\\"
+              window.top.location.href = \\"https://shop1/admin/oauth/authorize?client_id=key&scope=scope&redirect_uri=http://myshop.myshopify.com/auth/callback\\"
             </script>
           </head>
         </html>"

--- a/routes/tests/shopifyAuth.test.js
+++ b/routes/tests/shopifyAuth.test.js
@@ -4,7 +4,7 @@ const http = require('http');
 const express = require('express');
 
 const { MemoryStrategy } = require('../../strategies');
-const createShopifyAuthRouter = require('../shopifyAuth');
+const createShopifyAuthRoutes = require('../shopifyAuth');
 
 const PORT = 3000;
 const BASE_URL = `http://localhost:${PORT}`
@@ -62,17 +62,16 @@ describe('shopifyAuth', async () => {
 function createServer(afterAuth) {
   const app = express();
 
-  app.use(
-    '/',
-    createShopifyAuthRouter({
-      apiKey: 'key',
-      secret: 'secret',
-      scope: ['scope'],
-      shopStore: new MemoryStrategy(),
-      afterAuth,
-    }),
-  );
+  const {auth, callback} = createShopifyAuthRoutes({
+    apiKey: 'key',
+    secret: 'secret',
+    scope: ['scope'],
+    shopStore: new MemoryStrategy(),
+    afterAuth,
+  });
 
+  app.use('/', auth);
+  app.use('/callback', callback);
   server = http.createServer(app);
 
   return new Promise((resolve, reject) => {

--- a/routes/tests/shopifyAuth.test.js
+++ b/routes/tests/shopifyAuth.test.js
@@ -24,7 +24,7 @@ describe('shopifyAuth', async () => {
 
   describe('/', () => {
     it('responds to get requests by returning a redirect page', async () => {
-      const response = await fetch(`${BASE_URL}/?shop=shop1`);
+      const response = await fetch(`${BASE_URL}/auth?shop=shop1`);
       const data = await response.text();
 
       expect(response.status).toBe(200);
@@ -32,7 +32,7 @@ describe('shopifyAuth', async () => {
     });
 
     it('responds with a 400 when no shop query parameter is given', async () => {
-      const response = await fetch(BASE_URL);
+      const response = await fetch(`${BASE_URL}/auth`);
       const data = await response.text();
 
       expect(response.status).toBe(400);
@@ -63,6 +63,7 @@ function createServer(afterAuth) {
   const app = express();
 
   const {auth, callback} = createShopifyAuthRoutes({
+    host: 'http://myshop.myshopify.com',
     apiKey: 'key',
     secret: 'secret',
     scope: ['scope'],
@@ -70,8 +71,8 @@ function createServer(afterAuth) {
     afterAuth,
   });
 
-  app.use('/', auth);
-  app.use('/callback', callback);
+  app.use('/auth', auth);
+  app.use('/auth/callback', callback);
   server = http.createServer(app);
 
   return new Promise((resolve, reject) => {

--- a/strategies/SQLStrategy.js
+++ b/strategies/SQLStrategy.js
@@ -21,8 +21,8 @@ module.exports = class SQLStrategy {
         table.string('access_token');
         table.unique('shopify_domain');
       })
-      .catch(err => {
-        console.log(err);
+      .catch(error => {
+        console.log(error);
       });
   }
 


### PR DESCRIPTION
Closes #43 

## Summary
Previously we had a really dumb setup where we just hoped some routes were set a certain way.

To fix this we:
- use `request.baseUrl` to build our callback route taking into account where the router is mounted
- add a parameter to `withShop` so that we can redirect to the right url no matter where the user's code is mounted

This means you can stick our routes on `/shopify` or something similar if you don't want it to conflict with existing routes.

## 🎩  instructions
- run `yarn link` in your local clone of this repo
- run `yarn link @shopify/shopify-express` in your local clone of `shopify-node-app`
- fetch this branch in `shopify-express`
- fetch `update/shopify-express-callback-url-fix` in `shopify-node-app`
- run both projects (with whatever proxying shenanigans you might need)
- go to the app on your store

It should work even if you change what path the routes are mounted on. (as long as they are whitelisted properly)