### PR TITLE
Remove CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,0 @@
-# Change Log
-
-## v1.0.0-alpha.1 (11-06-2017)
-
-* Initial release including `shopifyRouter`, `withShop`, and `withWebhook`
-


### PR DESCRIPTION
We use the Github Releases feature to make notes about changes to the project. Therefore, this file is useless.