### PR TITLE
Redis Strategy does not account for the redis key not existing

### DIFF
--- a/strategies/RedisStrategy.js
+++ b/strategies/RedisStrategy.js
@@ -22,7 +22,11 @@ module.exports = class RedisStrategy {
         return done(err);
       }
 
-      done(null, shopData);
+      if (shopData) {
+        done(null, shopData);
+      } else {
+        done(null, {});
+      }
     });
   }
 };


### PR DESCRIPTION
On a "new" install, the redis call to hgetall returns shopData as null.

As a result

> TypeError: Cannot destructure property `accessToken` of 'undefined' or 'null'.

If shopdata return shopdata, else return {}