### PR TITLE
Adding ability to use nest objects in the URL

### DIFF
--- a/routes/shopifyApiProxy.js
+++ b/routes/shopifyApiProxy.js
@@ -1,4 +1,4 @@
-const querystring = require('querystring');
+const querystring = require('qs');
 const fetch = require('node-fetch');
 
 const DISALLOWED_URLS = [


### PR DESCRIPTION
Adding the ability for Shopify API proxy to work with URLs containing nested objects, such as requests for a single asset file from a store.  Currently, the API proxy simply drops the nested object.
This is a crazy simple change but will save many a lot of frustration.  This changes the package used for _stringifying_ the URL query parameters from the package "querystring" to "qs".  The constant which is used for referencing this package retains its name of "querystring"—despite the package changing— for purposes of clarity and code readability.