### PR TITLE
Fix HMAC failure on webhook post

### DIFF
--- a/middleware/webhooks.js
+++ b/middleware/webhooks.js
@@ -13,7 +13,7 @@ module.exports = function configureWithWebhook({ secret, shopStore }) {
         const rawBody = await getRawBody(request);
         const generated_hash = crypto
           .createHmac('sha256', secret)
-          .update(rawBody)
+          .update(rawBody.body)
           .digest('base64');
 
         if (generated_hash !== hmac) {


### PR DESCRIPTION
Fixes HMAC error:

```js
Error: Unable to verify request HMAC
    at withWebhook (.../node_modules/@shopify/shopify-express/middleware/webhooks.js:30:22)
    at <anonymous>
    at process._tickCallback (internal/process/next_tick.js:188:7)
```

```js
app.post('/webhook/order/new', withWebhook((error, request) => {
  if (error) {
    console.error(error);
    // console.log(request);
    return;
  }

  console.log('New Order!');
  console.log('Details: ', request.webhook);
  console.log('Body:', request.body);
}));
```

Maybe there is a better way?