### PR TITLE
Change sqlite version 

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node-fetch": "^1.7.3",
     "prop-types": "^15.6.1",
     "raw-body": "^2.3.2",
-    "sqlite3": "^3.1.9",
+    "sqlite3": "^4.0.0",
     "url": "^0.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
There is a 403 when building with sqlite 3.1.9 (which was deprecated) updating dependency fixes the issue.