### PR TITLE
🗒️ document deprecation of the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
+## Deprecation
+
+:exclamation: **This project is deprecated**. This means Shopify will not be maintaining it going forward. If you are interested in building a Shopify app using first party tools then check out our other libraries:
+
+* [@shopify/koa-shopify-auth](https://github.com/Shopify/quilt/tree/master/packages/koa-shopify-auth)
+* [@shopify/koa-shopify-graphql-proxy](https://github.com/Shopify/quilt/blob/master/packages/koa-shopify-graphql-proxy/README.md)
+* [shopify_app](https://github.com/Shopify/shopify_app)
+
+These are all used internally and written against technologies we use for our own applications. Of course, if you wish to continue using Express, feel free to fork this codebase and continue it as you wish.
+
 # shopify-express
 
 A small set of abstractions that will help you quickly build an Express.js app that consumes the Shopify API.
-
-:exclamation: **This project is currently in alpha status**. This means that the API could change at any time. It also means that your feedback will have a big impact on how the project evolves, so please feel free to [open issues](https://github.com/shopify/shopify-express/issues) if there is something you would like to see added.
-
 
 ## Example
 


### PR DESCRIPTION
This PR adds a deprecation notice to the README, and links out to the libraries we are actually maintaining going forward.
* [@shopify/koa-shopify-auth](https://github.com/Shopify/quilt/tree/master/packages/koa-shopify-auth)
* [@shopify/koa-shopify-graphql-proxy](https://github.com/Shopify/quilt/blob/master/packages/koa-shopify-graphql-proxy/README.md)
* [shopify_app](https://github.com/Shopify/shopify_app)

This has been overdue for a while. It's no secret that we haven't been maintaining this package for a long time. We've released other packages as open source which more adhere to the tech-stack and model we use in node applications and removed this package from our official documentation already. In making this change I'd like to redirect as many people as possible from this repo to packages that we will actually be maintaining.

To everyone outside of Shopify who has contributed to this package, thank you for your hard work, feel free to fork this or use it as inspiration for your own Express libraries as you like. ❤️