### PR TITLE
ITP2 fixes

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,1 +1,2 @@
 module.exports.TEST_COOKIE_NAME = 'shopifyTestCookie';
+module.exports.TOP_LEVEL_OAUTH_COOKIE_NAME = 'shopifyTopLevelOAuth';

--- a/constants.js
+++ b/constants.js
@@ -1,0 +1,1 @@
+module.exports.TEST_COOKIE_NAME = 'shopifyTestCookie';

--- a/middleware/withShop.js
+++ b/middleware/withShop.js
@@ -1,3 +1,5 @@
+const TEST_COOKIE_NAME = 'shopifyTestCookie';
+
 module.exports = function withShop({ authBaseUrl } = {}) {
   return function verifyRequest(request, response, next) {
     const { query: { shop }, session, baseUrl } = request;
@@ -6,6 +8,8 @@ module.exports = function withShop({ authBaseUrl } = {}) {
       next();
       return;
     }
+
+    response.cookie(TEST_COOKIE_NAME, '1');
 
     if (shop) {
       response.redirect(`${authBaseUrl || baseUrl}/auth?shop=${shop}`);

--- a/middleware/withShop.js
+++ b/middleware/withShop.js
@@ -1,4 +1,4 @@
-const TEST_COOKIE_NAME = 'shopifyTestCookie';
+const {TEST_COOKIE_NAME} = require('../constants');
 
 module.exports = function withShop({ authBaseUrl } = {}) {
   return function verifyRequest(request, response, next) {

--- a/middleware/withShop.js
+++ b/middleware/withShop.js
@@ -1,10 +1,11 @@
-const {TEST_COOKIE_NAME} = require('../constants');
+const {TEST_COOKIE_NAME, TOP_LEVEL_OAUTH_COOKIE_NAME} = require('../constants');
 
 module.exports = function withShop({ authBaseUrl } = {}) {
   return function verifyRequest(request, response, next) {
     const { query: { shop }, session, baseUrl } = request;
 
     if (session && session.accessToken) {
+      response.cookie(TOP_LEVEL_OAUTH_COOKIE_NAME);
       next();
       return;
     }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "body-parser": "^1.18.2",
     "connect-redis": "^3.3.0",
+    "cookie-parser": "^1.4.3",
     "express": "^4.16.2",
     "express-session": "^1.15.3",
     "knex": "^0.13.0",

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const bodyParser = require('body-parser');
+const cookieParser = require('cookie-parser')
 
 const createShopifyAuthRoutes = require('./shopifyAuth');
 const shopifyApiProxy = require('./shopifyApiProxy');
@@ -7,10 +8,12 @@ const shopifyApiProxy = require('./shopifyApiProxy');
 module.exports = function createRouter(shopifyConfig) {
   const router = express.Router();
   const rawParser = bodyParser.raw({ type: '*/*' });
-  const {auth, callback} = createShopifyAuthRoutes(shopifyConfig)
+  const simpleCookieParser = cookieParser();
+  const {auth, callback, enableCookies} = createShopifyAuthRoutes(shopifyConfig)
 
   router.use('/auth/callback', callback);
-  router.use('/auth', auth);
+  router.use('/auth/enable_cookies', enableCookies);
+  router.use('/auth', simpleCookieParser, auth);
   router.use(
     '/api',
     rawParser,

--- a/routes/shopifyAuth.js
+++ b/routes/shopifyAuth.js
@@ -475,22 +475,36 @@ information. They expire after 30 days.`
     window.apiKey = "${apiKey}";
     window.shopOrigin = "https://${shop}";
     
-    function setCookieAndRedirect() {
-      document.cookie = "shopify.cookies_persist=true";
-      window.location.href = window.shopOrigin + "/admin/apps/" + window.apiKey;
-    }
-    
-    document.addEventListener("DOMContentLoaded", function() {
-      if (document.hasStorageAccess) {
-        var itpContent = document.querySelector('#CookiePartitionPrompt');
-        itpContent.style.display = 'block';
-    
-        var button = document.querySelector('#AcceptCookies');
-        button.addEventListener('click', setCookieAndRedirect);
-      } else {
-        setCookieAndRedirect();
+    (function() {
+      function setCookieAndRedirect() {
+        document.cookie = "shopify.cookies_persist=true";
+        window.location.href = window.shopOrigin + "/admin/apps/" + window.apiKey;
       }
-    });
+
+      function shouldDisplayPrompt() {
+        if (navigator.userAgent.indexOf('com.jadedpixel.pos') !== -1) {
+          return false;
+        }
+
+        if (navigator.userAgent.indexOf('Shopify Mobile/iOS') !== -1) {
+          return false;
+        }
+
+        return Boolean(document.hasStorageAccess);
+      }
+
+      document.addEventListener("DOMContentLoaded", function() {
+        if (shouldDisplayPrompt()) {
+          var itpContent = document.querySelector('#CookiePartitionPrompt');
+          itpContent.style.display = 'block';
+
+          var button = document.querySelector('#AcceptCookies');
+          button.addEventListener('click', setCookieAndRedirect);
+        } else {
+          setCookieAndRedirect();
+        }
+      });
+    })();
   </script>
 </head>
 <body>

--- a/routes/shopifyAuth.js
+++ b/routes/shopifyAuth.js
@@ -2,9 +2,7 @@ const querystring = require('querystring');
 const crypto = require('crypto');
 const fetch = require('node-fetch');
 
-const {TEST_COOKIE_NAME} = require('../constants');
-
-const TOP_LEVEL_OAUTH_COOKIE_NAME = 'shopifyTopLevelOAuth';
+const {TEST_COOKIE_NAME, TOP_LEVEL_OAUTH_COOKIE_NAME} = require('../constants');
 
 module.exports = function createShopifyAuthRoutes({
   host,

--- a/routes/shopifyAuth.js
+++ b/routes/shopifyAuth.js
@@ -2,6 +2,9 @@ const querystring = require('querystring');
 const crypto = require('crypto');
 const fetch = require('node-fetch');
 
+const TEST_COOKIE_NAME = 'shopifyTestCookie';
+const TOP_LEVEL_OAUTH_COOKIE_NAME = 'shopifyTopLevelOAuth';
+
 module.exports = function createShopifyAuthRoutes({
   host,
   apiKey,
@@ -21,6 +24,13 @@ module.exports = function createShopifyAuthRoutes({
         return response.status(400).send('Expected a shop query parameter');
       }
 
+      if (!request.cookies[TEST_COOKIE_NAME]) {
+        // This is to avoid a redirect loop if the app doesn't use verifyRequest or set the test cookie elsewhere.
+        response.cookie(TEST_COOKIE_NAME, '1');
+        topLevelRedirect(response, `${host}${baseUrl}/enable_cookies?${querystring.stringify({shop})}`);
+        return;
+      }
+
       const redirectTo = `https://${shop}/admin/oauth/authorize`;
 
       const redirectParams = {
@@ -34,16 +44,13 @@ module.exports = function createShopifyAuthRoutes({
         redirectParams['grant_options[]'] = 'per-user';
       }
 
-      response.send(
-        `<!DOCTYPE html>
-        <html>
-          <head>
-            <script type="text/javascript">
-              window.top.location.href = "${redirectTo}?${querystring.stringify(redirectParams)}"
-            </script>
-          </head>
-        </html>`,
-      );
+      if (!request.cookies[TOP_LEVEL_OAUTH_COOKIE_NAME]) {
+        response.cookie(TOP_LEVEL_OAUTH_COOKIE_NAME, '1');
+        topLevelRedirect(response, `${redirectTo}?${querystring.stringify(redirectParams)}`);
+        return;
+      }
+
+      response.redirect(`${redirectTo}?${querystring.stringify(redirectParams)}`);
     },
 
     // Users are redirected here after clicking `Install`.
@@ -104,6 +111,436 @@ module.exports = function createShopifyAuthRoutes({
         console.error('🔴 Error storing shop access token', error);
         next(error);
       }
+    },
+
+    enableCookies(request, response) {
+      const HEADING = 'Enable cookies';
+      const BODY = 'You must manually enable cookies in this browser in order to use this app within Shopify.'
+      const FOOTER = `Cookies let the app authenticate you by temporarily storing your preferences and personal
+information. They expire after 30 days.`
+      const ACTION = 'Enable cookies';
+
+      const { query, baseUrl } = request;
+      const { shop } = query;
+
+      if (shop == null) {
+        return response.status(400).send('Expected a shop query parameter');
+      }
+
+      response.send(`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <style>
+    html,
+    body {
+      min-height:100%;
+      height:100%; 
+      font-size:1.5rem;
+      font-weight:400;
+      line-height:2rem;
+      text-transform:initial;
+      letter-spacing:initial;
+      font-weight:400;
+      color:#212b36;
+      font-family:-apple-system, BlinkMacSystemFont, San Francisco, Roboto, Segoe UI, Helvetica Neue, sans-serif;
+    }
+
+    @media (min-width: 40em) {
+      html,
+      body {
+        font-size:1.4rem;
+      }
+    }
+
+    html {
+      position:relative;
+      font-size:62.5%;
+      -webkit-font-smoothing:antialiased;
+      -moz-osx-font-smoothing:grayscale;
+      -webkit-text-size-adjust:100%;
+      -ms-text-size-adjust:100%;
+      text-size-adjust:100%;
+      text-rendering:optimizeLegibility;
+    }
+
+    body {
+      min-height:100%;
+      margin:0;
+      padding:0;
+      background-color:#f4f6f8;
+    }
+
+    *,
+    *::before,
+    *::after{
+      box-sizing:border-box; }
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    p {
+      margin:0;
+      font-size:1em;
+      font-weight:400;
+    }
+
+    #CookiePartitionPrompt {
+      display: none;
+    }
+
+    .Polaris-Page {
+      margin:0 auto;
+      padding:0;
+      max-width:99.8rem; 
+    }
+
+    @media (min-width: 30.625em) {
+      .Polaris-Page {
+        padding:0 2rem;
+      }
+    }
+    @media (min-width: 46.5em) {
+      .Polaris-Page {
+        padding:0 3.2rem;
+      }
+    }
+
+    .Polaris-Page__Content {
+      margin:2rem 0;
+    }
+
+    @media (min-width: 46.5em) {
+      .Polaris-Page__Content {
+        margin-top:2rem;
+      }
+    }
+
+    @media (min-width: 46.5em) {
+      .Polaris-Page {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+      }
+    }
+
+    .Polaris-Layout {
+      display:-webkit-box;
+      display:-ms-flexbox;
+      display:flex;
+      -ms-flex-wrap:wrap;
+      flex-wrap:wrap;
+      -webkit-box-pack:center;
+      -ms-flex-pack:center;
+      justify-content:center;
+      -webkit-box-align:start;
+      -ms-flex-align:start;
+      align-items:flex-start;
+      margin-top:-2rem;
+      margin-left:-2rem;
+    }
+
+    .Polaris-Layout__Section {
+      -webkit-box-flex:2;
+      -ms-flex:2 2 48rem;
+      flex:2 2 48rem;
+      min-width:51%;
+    }
+
+    .Polaris-Layout__Section--fullWidth {
+      -webkit-box-flex:1;
+      -ms-flex:1 1 100%;
+      flex:1 1 100%;
+    }
+
+    .Polaris-Layout__Section {
+      max-width:calc(100% - 2rem);
+      margin-top:2rem;
+      margin-left:2rem;
+    }
+
+    .Polaris-Stack {
+      margin-top:-1.6rem;
+      margin-left:-1.6rem;
+      display:-webkit-box;
+      display:-ms-flexbox;
+      display:flex;
+      -ms-flex-wrap:wrap;
+      flex-wrap:wrap;
+      -webkit-box-align:stretch;
+      -ms-flex-align:stretch;
+      align-items:stretch;
+    }
+
+    .Polaris-Stack > .Polaris-Stack__Item {
+      margin-top:1.6rem;
+      margin-left:1.6rem;
+      max-width:calc(100% - 1.6rem);
+    }
+
+    .Polaris-Stack__Item {
+      -webkit-box-flex:0;
+      -ms-flex:0 0 auto;
+      flex:0 0 auto;
+      min-width:0;
+    }
+
+    .Polaris-Heading {
+      font-size:1.7rem;
+      font-weight:600;
+      line-height:2.4rem;
+      margin:0;
+    }
+
+    @media (min-width: 40em) {
+      .Polaris-Heading {
+        font-size:1.6rem;
+      }
+    }
+
+    .Polaris-Card {
+      overflow:hidden;
+      background-color:white;
+      box-shadow:0 0 0 1px rgba(63, 63, 68, 0.05), 0 1px 3px 0 rgba(63, 63, 68, 0.15);
+    }
+
+    .Polaris-Card + .Polaris-Card {
+      margin-top:2rem;
+    }
+
+    @media (min-width: 30.625em) {
+      .Polaris-Card {
+        border-radius:3px;
+      }
+    }
+
+    .Polaris-Card__Header {
+      padding:2rem 2rem 0;
+    }
+
+    .Polaris-Card__Section {
+      padding:2rem;
+    }
+
+    .Polaris-Card__Section + .Polaris-Card__Section {
+      border-top:1px solid #dfe3e8;
+    }
+
+    .Polaris-Card__Section--subdued {
+      background-color:#f9fafb;
+    }
+
+
+    .Polaris-Stack--distributionTrailing {
+      -webkit-box-pack:end;
+      -ms-flex-pack:end;
+      justify-content:flex-end;
+    }
+
+    .Polaris-Stack--vertical {
+      -webkit-box-orient:vertical;
+      -webkit-box-direction:normal;
+      -ms-flex-direction:column;
+      flex-direction:column;
+    }
+
+    .Polaris-Button {
+      fill:#637381;
+      position:relative;
+      display:-webkit-inline-box;
+      display:-ms-inline-flexbox;
+      display:inline-flex;
+      -webkit-box-align:center;
+      -ms-flex-align:center;
+      align-items:center;
+      -webkit-box-pack:center;
+      -ms-flex-pack:center;
+      justify-content:center;
+      min-height:3.6rem;
+      min-width:3.6rem;
+      margin:0;
+      padding:0.7rem 1.6rem;
+      background:linear-gradient(to bottom, white, #f9fafb);
+      border:1px solid #c4cdd5;
+      box-shadow:0 1px 0 0 rgba(22, 29, 37, 0.05);
+      border-radius:3px;
+      line-height:1;
+      color:#212b36;
+      text-align:center;
+      cursor:pointer;
+      -webkit-user-select:none;
+      -moz-user-select:none;
+      -ms-user-select:none;
+      user-select:none;
+      text-decoration:none;
+      transition-property:background, border, box-shadow;
+      transition-duration:200ms;
+      transition-timing-function:cubic-bezier(0.64, 0, 0.35, 1);
+    }
+
+    .Polaris-Button:hover {
+      background:linear-gradient(to bottom, #f9fafb, #f4f6f8);
+      border-color:#c4cdd5;
+    }
+
+    .Polaris-Button:focus {
+      border-color:#5c6ac4;
+      outline:0;
+      box-shadow:0 0 0 1px #5c6ac4;
+    }
+
+    .Polaris-Button:active {
+      background:linear-gradient(to bottom, #f4f6f8, #f4f6f8);
+      border-color:#c4cdd5;
+      box-shadow:0 0 0 0 transparent, inset 0 1px 1px 0 rgba(99, 115, 129, 0.1), inset 0 1px 4px 0 rgba(99, 115, 129, 0.2);
+    }
+
+    .Polaris-Button.Polaris-Button--disabled {
+      fill:#919eab;
+      transition:none;
+      background:linear-gradient(to bottom, #f4f6f8, #f4f6f8);
+      color:#919eab;
+    }
+
+    .Polaris-Button__Content {
+      font-size:1.5rem;
+      font-weight:400;
+      line-height:1.6rem;
+      text-transform:initial;
+      letter-spacing:initial;
+      position:relative;
+      display:-webkit-box;
+      display:-ms-flexbox;
+      display:flex;
+      -webkit-box-pack:center;
+      -ms-flex-pack:center;
+      justify-content:center;
+      -webkit-box-align:center;
+      -ms-flex-align:center;
+      align-items:center;
+      min-width:1px;
+      min-height:1px;
+    }
+      
+    @media (min-width: 40em) {
+      .Polaris-Button__Content {
+        font-size:1.4rem;
+      } 
+    }
+
+    .Polaris-Button--primary {
+      background:linear-gradient(to bottom, #6371c7, #5563c1);
+      border-color:#3f4eae;
+      box-shadow:inset 0 1px 0 0 #6774c8, 0 1px 0 0 rgba(22, 29, 37, 0.05), 0 0 0 0 transparent;
+      color:white;
+      fill:white;
+    }
+
+    .Polaris-Button--primary:hover {
+      background:linear-gradient(to bottom, #5c6ac4, #4959bd);
+      border-color:#3f4eae;
+      color:white;
+      text-decoration:none;
+    }
+
+    .Polaris-Button--primary:focus {
+      border-color:#202e78;
+      box-shadow:inset 0 1px 0 0 #6f7bcb, 0 1px 0 0 rgba(22, 29, 37, 0.05), 0 0 0 1px #202e78;
+    }
+
+    .Polaris-Button--primary:active {
+      background:linear-gradient(to bottom, #3f4eae, #3f4eae);
+      border-color:#38469b;
+      box-shadow:inset 0 0 0 0 transparent, 0 1px 0 0 rgba(22, 29, 37, 0.05), 0 0 1px 0 #38469b;
+    }
+
+    .Polaris-Button--primary.Polaris-Button--disabled {
+      fill:white;
+      background:linear-gradient(to bottom, #bac0e6, #bac0e6);
+      border-color:#a7aedf;
+      box-shadow:none;
+      color:white;
+    }
+  </style>
+  <base target="_top">
+  <title>Redirecting…</title>
+
+  <script>
+    window.apiKey = "${apiKey}";
+    window.shopOrigin = "https://${shop}";
+    
+    function setCookieAndRedirect() {
+      document.cookie = "shopify.cookies_persist=true";
+      window.location.href = window.shopOrigin + "/admin/apps/" + window.apiKey;
+    }
+    
+    document.addEventListener("DOMContentLoaded", function() {
+      if (document.hasStorageAccess) {
+        var itpContent = document.querySelector('#CookiePartitionPrompt');
+        itpContent.style.display = 'block';
+    
+        var button = document.querySelector('#AcceptCookies');
+        button.addEventListener('click', setCookieAndRedirect);
+      } else {
+        setCookieAndRedirect();
+      }
+    });
+  </script>
+</head>
+<body>
+  <main id="CookiePartitionPrompt">
+    <div class="Polaris-Page">
+      <div class="Polaris-Page__Content">
+        <div class="Polaris-Layout">
+          <div class="Polaris-Layout__Section">
+            <div class="Polaris-Stack Polaris-Stack--vertical">
+              <div class="Polaris-Stack__Item">
+                <div class="Polaris-Card">
+                  <div class="Polaris-Card__Header">
+                    <h1 class="Polaris-Heading">${HEADING}</h1>
+                  </div>
+                  <div class="Polaris-Card__Section">
+                    <p>${BODY}</p>
+                  </div>
+                  <div class="Polaris-Card__Section Polaris-Card__Section--subdued">
+                    <p>${FOOTER}</p>
+                  </div>
+                </div>
+              </div>
+              <div class="Polaris-Stack__Item">
+                <div class="Polaris-Stack Polaris-Stack--distributionTrailing">
+                  <div class="Polaris-Stack__Item">
+                    <button type="button" class="Polaris-Button Polaris-Button--primary" id="AcceptCookies">
+                      <span class="Polaris-Button__Content"><span>${ACTION}</span></span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+</body>
+</html>`);
     }
   };
 };
+
+function topLevelRedirect(response, url) {
+  response.send(
+    `<!DOCTYPE html>
+    <html>
+      <head>
+        <script type="text/javascript">
+          window.top.location.href = "${url}"
+        </script>
+      </head>
+    </html>`,
+  );
+}

--- a/routes/shopifyAuth.js
+++ b/routes/shopifyAuth.js
@@ -50,6 +50,7 @@ module.exports = function createShopifyAuthRoutes({
         return;
       }
 
+      response.clearCookie(TOP_LEVEL_OAUTH_COOKIE_NAME);
       response.redirect(`${redirectTo}?${querystring.stringify(redirectParams)}`);
     },
 

--- a/routes/shopifyAuth.js
+++ b/routes/shopifyAuth.js
@@ -2,7 +2,8 @@ const querystring = require('querystring');
 const crypto = require('crypto');
 const fetch = require('node-fetch');
 
-const TEST_COOKIE_NAME = 'shopifyTestCookie';
+const {TEST_COOKIE_NAME} = require('../constants');
+
 const TOP_LEVEL_OAUTH_COOKIE_NAME = 'shopifyTopLevelOAuth';
 
 module.exports = function createShopifyAuthRoutes({

--- a/routes/tests/__snapshots__/shopifyAuth.test.js.snap
+++ b/routes/tests/__snapshots__/shopifyAuth.test.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`shopifyAuth / responds to get requests by returning a redirect page 1`] = `
-"<!DOCTYPE html>
-        <html>
-          <head>
-            <script type=\\"text/javascript\\">
-              window.top.location.href = \\"https://shop1/admin/oauth/authorize?baseUrl=%2Fauth&scope=scope&client_id=key&redirect_uri=http%3A%2F%2Fmyshop.myshopify.com%2Fauth%2Fcallback\\"
-            </script>
-          </head>
-        </html>"
-`;
-
 exports[`shopifyAuth / responds with a 400 when no shop query parameter is given 1`] = `"Expected a shop query parameter"`;
+
+exports[`shopifyAuth / with cookie access but without a prior top-level attempt responds to get requests by returning a redirect page 1`] = `
+"<!DOCTYPE html>
+    <html>
+      <head>
+        <script type=\\"text/javascript\\">
+          window.top.location.href = \\"https://shop1/admin/oauth/authorize?baseUrl=%2Fauth&scope=scope&client_id=key&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth%2Fcallback\\"
+        </script>
+      </head>
+    </html>"
+`;

--- a/routes/tests/shopifyAuth.test.js
+++ b/routes/tests/shopifyAuth.test.js
@@ -57,13 +57,14 @@ describe('shopifyAuth', async () => {
     });
 
     describe('with cookie access and a prior top-level attempt', () => {
-      it('redirects directly to the grant page', async () => {
+      it('redirects directly to the grant page and removes top-level cookie', async () => {
         const headers = {cookie: 'shopifyTestCookie=1; shopifyTopLevelOAuth=1;'};
         const response = await fetch(`${BASE_URL}/auth?shop=shop1`, {headers, redirect: 'manual'});
         const data = await response.text();
 
         expect(response.status).toBe(302);
         expect(response.headers.get('location')).toContain('https://shop1/admin/oauth/authorize');
+        expect(response.headers.get('cookie')).toBe(null);
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -560,6 +560,13 @@ convert-source-map@^1.4.0, convert-source-map@^1.5.0:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
+cookie-parser@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/cookie-parser/-/cookie-parser-1.4.3.tgz#0fe31fa19d000b95f4aadf1f53fdc2b8a203baa5"
+  dependencies:
+    cookie "0.3.1"
+    cookie-signature "1.0.6"
+
 cookie-signature@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"


### PR DESCRIPTION
This PR contains the necessary changes to work around Safari 12's ITP 2.0 implementation. In short, it implements this flow:

![image](https://user-images.githubusercontent.com/19682/45030452-da6c4600-b019-11e8-8dcf-68b0aadd17a2.png)

To tophat:

`yarn link` here and then `yarn link "@shopify/shopify-express"` in `shopify-node-app`. Use the stock app.